### PR TITLE
Corrige um problema de escopo ao utilizar o método gsap.context().

### DIFF
--- a/app/components/layouts/navbar/hamburger-menu/icon-hamburger/icon-hamburger.tsx
+++ b/app/components/layouts/navbar/hamburger-menu/icon-hamburger/icon-hamburger.tsx
@@ -58,7 +58,7 @@ const IconHamburger: React.FC<IconHamburgerProps> = ({
           });
         }
       }
-    }, [isColumnFormatOpen]);
+    }, [elements]);
 
     return () => toggleIconHamburger.revert();
   }, [isColumnFormatOpen]);


### PR DESCRIPTION
Ajustei o escopo do método toggleIconHamburger para assegurar que esteja válido de acordo com as regras do GSAP.